### PR TITLE
PLAENH-42: enabled flysystem_azure

### DIFF
--- a/conf/cmi/core.extension.yml
+++ b/conf/cmi/core.extension.yml
@@ -31,6 +31,8 @@ module:
   file: 0
   file_mdm: 0
   filter: 0
+  flysystem: 0
+  flysystem_azure: 0
   focal_point: 0
   gin_toolbar: 0
   hdbt_admin_editorial: 0


### PR DESCRIPTION
# PLAENH-42
Encountered issue on gredi integration storing data on azure blob storage.

## What was done
Enabled flysystem_azure which is mandatory for azure blob storage.

* This thing was fixed

## How to install

* Make sure your instance is up and running on correct branch.
  * `git pull origin INSERT_BRANCH_HERE`
  * `make fresh`
* Run `make drush-cr`

## How to test
Navigate to the Extend Tab and search after flysystem_azure.

* [ ] Check that this feature works
* [ ] Check that code follows our standards

## Designers review
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [x] This PR does not need designers review
* [ ] This PR has been visually reviewed by a designer (Name of the designer)

## Other PRs
No
