### PR TITLE
Disable automatic deploy when something is pushed to dev.

### DIFF
--- a/azure-pipelines-build.yml
+++ b/azure-pipelines-build.yml
@@ -1,23 +1,15 @@
-# Continuous integration (CI) triggers cause a pipeline to run whenever you push 
-# an update to the specified branches or you push specified tags.
-trigger:
-  batch: true
-  branches:
-    include:
-    - dev
-  paths:
-    exclude:
-    - README.md
+# Opt out of automatic deployment.
+trigger: none
 
-# Pull request (PR) triggers cause a pipeline to run whenever a pull request is 
-# opened with one of the specified target branches, or when updates are made to 
+# Pull request (PR) triggers cause a pipeline to run whenever a pull request is
+# opened with one of the specified target branches, or when updates are made to
 # such a pull request.
 #
-# GitHub creates a new ref when a pull request is created. The ref points to a 
-# merge commit, which is the merged code between the source and target branches 
+# GitHub creates a new ref when a pull request is created. The ref points to a
+# merge commit, which is the merged code between the source and target branches
 # of the pull request.
 #
-# Opt out of pull request validation 
+# Opt out of pull request validation
 pr: none
 
 # By default, use self-hosted agents


### PR DESCRIPTION
## What was done
Disable automatic deploy when changes are pushed / merged to dev.

## How to test
* Read code change to check if everything makes sense
* Merge this to `dev` which hopefully will not automatically trigger the CI/CD pipeline